### PR TITLE
Add Plaza Deposit Incentives to Protocol List

### DIFF
--- a/src/data/protocols.json
+++ b/src/data/protocols.json
@@ -82,5 +82,12 @@
     "tag": "Stablecoin",
     "description": "Collateralize rETH to mint LUSD/BOLD stablecoin and earn extra DeFi rewards.",
     "link": "https://liquity.app/borrow/reth"
+  },
+  {
+    "id": 13,
+    "name": "Plaza Deposit Incentives",
+    "tag": "Yield",
+    "description": "Deposit rETH into the Plaza Deposit Program to receive Plaza Points on top of your rETH yield.",
+    "link": "https://deposit.plaza.finance"
   }
 ]


### PR DESCRIPTION
This PR adds Plaza Deposit Incentives to the list of supported protocols.

_Name_: Plaza Deposit Incentives

_Tag_: Yield

_Description_: Deposit rETH into the Plaza Deposit Program to receive Plaza Points on top of your rETH yield.

_Link_: https://deposit.plaza.finance/